### PR TITLE
Fix level of abstraction in TeamBuilder

### DIFF
--- a/lib/team_builder.ex
+++ b/lib/team_builder.ex
@@ -24,14 +24,10 @@ defmodule TeamBuilder do
   defp process_members(:quit, _, _, _, display_writer), do: display_writer.goodbye_message()
 
   defp process_members(new_members, teams, team_type, display_reader, display_writer) do
+    ConsoleWriter.clear_screen()
     members = Members.combine_members(teams, new_members)
-    new_teams = build_teams(team_type, members)
+    new_teams = Team.allocate_members(team_type, members)
     display_writer.display_teams(new_teams)
     request_members(team_type, new_teams, display_reader, display_writer)
-  end
-
-  defp build_teams(team_type, all_members) do
-    Team.empty_teams(team_type)
-    |> Team.allocate_members(all_members)
   end
 end

--- a/lib/teams.ex
+++ b/lib/teams.ex
@@ -3,13 +3,19 @@ defmodule TeamBuilder.Team do
     Enum.map(1..fixed_count, fn(number) -> team_skeleton(number) end)
   end
 
-  def allocate_members(teams, all_members) do
-    all_members
-    |> assign_team_numbers(teams)
+  def allocate_members(team_type, all_members) do
+    team_type
+    |> empty_teams
+    |> _allocate_members(all_members)
+  end
+
+  defp _allocate_members(teams, all_members) do
+    teams
+    |> assign_team_numbers(all_members)
     |> add_members(teams)
   end
 
-  defp assign_team_numbers(members, teams) do
+  defp assign_team_numbers(teams, members) do
     members
     |> Enum.with_index
     |> Enum.map(fn({member, index}) -> map_member_to_team(member, index, teams) end)

--- a/test/team_builder_test.exs
+++ b/test/team_builder_test.exs
@@ -5,7 +5,6 @@ defmodule TeamBuilderTest do
   alias TeamBuilder.ConsoleWriter
   doctest TeamBuilder
 
-
   @team_type %{:team_type => :fixed, :options => 4}
 
   defmodule FakeReader do

--- a/test/team_test.exs
+++ b/test/team_test.exs
@@ -3,10 +3,12 @@ defmodule TeamTest do
   doctest TeamBuilder
   alias TeamBuilder.Team
 
+  @team_type %{:team_type => :fixed, :options => 4}
+
   test "fixed number of teams created" do
     fixed_number_of_teams = 4
     expected_result = get_teams(fixed_number_of_teams)
-    assert Team.empty_teams(%{:team_type => :fixed, :options => 4}) == expected_result
+    assert Team.empty_teams(@team_type) == expected_result
   end
 
   test "two members generates two Teams" do
@@ -17,7 +19,7 @@ defmodule TeamTest do
               %{:team => 3, :names => []},
               %{:team => 4, :names => []}
             ]
-    assert Team.allocate_members(get_teams(4), [a1, a2]) == expected_result
+    assert Team.allocate_members(@team_type, [a1, a2]) == expected_result
   end
 
   test "eight members generates 4 Teams with 2 members each" do
@@ -29,7 +31,7 @@ defmodule TeamTest do
               %{:team => 3, :names => [a3, a7] },
               %{:team => 4, :names => [a4, a8] }
             ]
-    assert Team.allocate_members(get_teams(4), all_members) == expected_result
+    assert Team.allocate_members(@team_type, all_members) == expected_result
   end
 
   def generate_members(number) do


### PR DESCRIPTION
TeamBuilder was aware of how Team needed to allocate members to the teams and it shouldn't
