### PR TITLE
Separate building of teams from adding of new team members.

### DIFF
--- a/lib/commands.ex
+++ b/lib/commands.ex
@@ -1,0 +1,5 @@
+defmodule TeamBuilder.Commands  do
+  def translate_command("q"), do: :quit
+  def translate_command("b"), do: :build_teams
+  def translate_command(command), do: command
+end

--- a/lib/console_reader.ex
+++ b/lib/console_reader.ex
@@ -1,12 +1,27 @@
 defmodule TeamBuilder.ConsoleReader do
   alias TeamBuilder.Messages
+  alias TeamBuilder.Commands
 
-  def add_members() do
-    Messages.add_members()
-    |> append_space
+  def next_command() do
+    next_command_message()
     |> IO.gets
     |> String.strip
+    |> Commands.translate_command
   end
 
-  defp append_space(message), do: message <> " "
+  defp next_command_message() do
+    Messages.add_members()
+    |> append_commands
+  end
+
+  defp append_commands(message) do
+    message
+    |> append_char(" (")
+    |> append_char(Messages.quit())
+    |> append_char(" - ")
+    |> append_char(Messages.build_teams())
+    |> append_char("): ")
+  end
+
+  defp append_char(message, chars), do: message <> chars
 end

--- a/lib/members.ex
+++ b/lib/members.ex
@@ -1,14 +1,16 @@
 defmodule TeamBuilder.Members do
-  def combine_members(teams, new_members) do
-    extract_all_members(teams) ++ new_members
-  end
-
-  def next_instruction(display_reader) do
-    display_reader.add_members()
+  def next_member(display_reader) do
+    display_reader.next_command()
     |> parse_input
   end
 
-  defp parse_input("q"), do: :quit
+  def add_to_members(members, new_member) do
+    members ++ [new_member]
+  end
+
+  def combine_members(teams, new_members) do
+    extract_all_members(teams) ++ new_members
+  end
 
   defp parse_input(input) do
     [input]

--- a/lib/messages.ex
+++ b/lib/messages.ex
@@ -1,7 +1,11 @@
 defmodule TeamBuilder.Messages do
   def welcome(), do: "Welcome to TeamBuilder. Please add your first invitee."
 
-  def add_members(), do: "Add Team Members ([q] to quit):"
+  def add_members(), do: "Add Team Members"
+
+  def quit(), do: "[q] Quit"
+
+  def build_teams(), do: "[b] Build Teams"
 
   def team_table_header(team_number), do: "Team #{team_number}:"
 

--- a/lib/team_builder.ex
+++ b/lib/team_builder.ex
@@ -7,27 +7,41 @@ defmodule TeamBuilder do
   def main(_) do
     ConsoleWriter.clear_screen()
     ConsoleWriter.welcome_message()
-    start_application(ConsoleReader, ConsoleWriter)
+    start_application([], ConsoleReader, ConsoleWriter)
   end
 
-  def start_application(display_reader, display_writer) do
-    %{:team_type => :fixed, :options => 4}
-    |> request_members([], display_reader, display_writer)
+  def start_application(members, display_reader, display_writer) do
+    prompt_for_command(members, display_reader, display_writer)
   end
 
-  def request_members(team_type, teams, display_reader, display_writer) do
+  def prompt_for_command(members, display_reader, display_writer) do
     display_reader
-    |> Members.next_instruction
-    |> process_members(teams, team_type, display_reader, display_writer)
+    |> next_command
+    |> process_command(members, display_reader, display_writer)
   end
 
-  defp process_members(:quit, _, _, _, display_writer), do: display_writer.goodbye_message()
+  defp process_command(:quit, _, _, display_writer), do: display_writer.goodbye_message()
 
-  defp process_members(new_members, teams, team_type, display_reader, display_writer) do
+  defp process_command(:build_teams, members, display_reader, display_writer) do
+    get_team_type()
+    |> build_teams(members, display_reader, display_writer)
+    prompt_for_command(members, display_reader, display_writer)
+  end
+
+  defp process_command(new_member, members, display_reader, display_writer) do
+    members
+    |> Members.add_to_members(new_member)
+    |> prompt_for_command(display_reader, display_writer)
+  end
+
+  defp build_teams(team_type, members, _, display_writer) do
     ConsoleWriter.clear_screen()
-    members = Members.combine_members(teams, new_members)
-    new_teams = Team.allocate_members(team_type, members)
-    display_writer.display_teams(new_teams)
-    request_members(team_type, new_teams, display_reader, display_writer)
+    team_type
+    |> Team.allocate_members(members)
+    |> display_writer.display_teams
   end
+
+  defp get_team_type(), do: %{:team_type => :fixed, :options => 4}
+
+  defp next_command(display_reader), do: display_reader.next_command
 end

--- a/test/commands_test.exs
+++ b/test/commands_test.exs
@@ -1,0 +1,17 @@
+defmodule CommandsTest do
+  use ExUnit.Case
+  doctest TeamBuilder
+  alias TeamBuilder.Commands
+
+  test "'q' value is interpreted as 'quit'" do
+    assert Commands.translate_command("q") == :quit
+  end
+
+  test "'b' value is interpreted as 'build teams'" do
+    assert Commands.translate_command("b") == :build_teams
+  end
+
+  test "any other value is interpreted as a new member command" do
+    assert Commands.translate_command("Bob") == "Bob"
+  end
+end

--- a/test/console_reader_test.exs
+++ b/test/console_reader_test.exs
@@ -7,8 +7,8 @@ defmodule ConsoleReaderTest do
   test "prompt for team member" do
     member = "Sarah"
     result = capture_io([input: member], fn ->
-      IO.write ConsoleReader.add_members()
+      IO.write ConsoleReader.next_command()
     end)
-    assert result == "Add Team Members ([q] to quit): Sarah"
+    assert result == "Add Team Members ([q] Quit - [b] Build Teams): Sarah"
   end
 end

--- a/test/members_test.exs
+++ b/test/members_test.exs
@@ -4,12 +4,12 @@ defmodule MembersTest do
   alias TeamBuilder.Members
 
   defmodule FakeDisplay do
-    def add_members(), do: "Sarah"
+    def next_command(), do: "Sarah"
   end
 
   test "obtain first single new member" do
     expected = ["Sarah"]
-    assert Members.next_instruction(FakeDisplay) == expected
+    assert Members.next_member(FakeDisplay) == expected
   end
 
   test "add new member to existing members" do

--- a/test/messages_test.exs
+++ b/test/messages_test.exs
@@ -9,7 +9,15 @@ defmodule MessagesTest do
   end
 
   test "add team member message" do
-    assert Messages.add_members() == "Add Team Members ([q] to quit):"
+    assert Messages.add_members() == "Add Team Members"
+  end
+
+  test "quit message" do
+    assert Messages.quit() == "[q] Quit"
+  end
+
+  test "build message" do
+    assert Messages.build_teams() == "[b] Build Teams"
   end
 
   test "team table header message" do

--- a/test/team_builder_test.exs
+++ b/test/team_builder_test.exs
@@ -8,8 +8,8 @@ defmodule TeamBuilderTest do
   @team_type %{:team_type => :fixed, :options => 4}
 
   defmodule FakeReader do
-   def add_members() do
-     "q"
+   def next_command() do
+     :quit
    end
   end
 
@@ -24,10 +24,24 @@ defmodule TeamBuilderTest do
   end
 
   test "typing q, closes the application" do
-    assert TeamBuilder.request_members(@team_type, [], FakeReader, FakeWriter) == "GoodBye"
+    assert TeamBuilder.prompt_for_command([], FakeReader, FakeWriter) == "GoodBye"
+  end
+
+  test "typing b, builds the 4 empty teams" do
+    input = "b\nq\n"
+    expected_result = "[ Team 1 ]\n\n" <>
+                      "[ Team 2 ]\n\n" <>
+                      "[ Team 3 ]\n\n" <>
+                      "[ Team 4 ]\n\n" <>
+                      "Thank you for using TeamBuilder.\n"
+    result = capture_io([input: input, capture_prompt: false], fn() ->
+      IO.write TeamBuilder.prompt_for_command([], ConsoleReader, ConsoleWriter)
+    end)
+    assert String.contains?(result, expected_result)
   end
 
   test "consecutive new members redistributed across teams" do
+    input = "Sarah\nJames\nb\nq\n"
     expected_result = "[ Team 1 ]\n" <>
                        "[1] Sarah\n\n" <>
                        "[ Team 2 ]\n" <>
@@ -35,10 +49,18 @@ defmodule TeamBuilderTest do
                        "[ Team 3 ]\n\n" <>
                        "[ Team 4 ]\n\n" <>
                        "Thank you for using TeamBuilder.\n"
-    input = "Sarah\nJames\nq\n"
     result = capture_io([input: input, capture_prompt: false], fn() ->
-      IO.write TeamBuilder.request_members(@team_type, [], ConsoleReader, ConsoleWriter)
+      IO.write TeamBuilder.prompt_for_command([], ConsoleReader, ConsoleWriter)
     end)
     assert String.contains?(result, expected_result)
+  end
+
+  def get_teams(4) do
+    [
+      %{:team => 1, :names => []},
+      %{:team => 2, :names => []},
+      %{:team => 3, :names => []},
+      %{:team => 4, :names => []},
+    ]
   end
 end


### PR DESCRIPTION
- Separated how command line commands were being handled
- Teams are now built only when ':build_teams' command is given
  @maikon
  @jsuchy
  @felipesere
