### PR TITLE
Refactor Teams module to aid readability

### DIFF
--- a/lib/random_selection.ex
+++ b/lib/random_selection.ex
@@ -1,0 +1,5 @@
+defmodule TeamBuilder.RandomSelection do
+  def take_random(members, team_count) do
+      Enum.take_random(members, team_count)
+  end
+end

--- a/lib/random_team_allocator.ex
+++ b/lib/random_team_allocator.ex
@@ -1,0 +1,37 @@
+defmodule TeamBuilder.RandomTeamAllocator do
+  def team_allocator(member_selector) do
+    fn(members, team_type) ->
+      assign_teams(members, team_type, member_selector)
+    end
+  end
+
+  def assign_teams([], _, _), do: []
+
+  def assign_teams(members, %{team_type: :fixed, options: fixed_count} = team_type, member_selector) do
+    {selection, remainder} = member_selection(members, fixed_count, member_selector)
+    with_team_number(selection) ++ assign_teams(remainder, team_type, member_selector)
+  end
+
+  defp member_selection(members, team_count, member_selector) do
+    members
+    |> member_selector.take_random(team_count)
+    |> partition(members)
+  end
+
+  defp partition(selected_members, all_members) do
+    all_members
+    |> Enum.partition(fn(x) -> Enum.any?(selected_members, fn(s) -> s == x end) end)
+  end
+
+  defp with_team_number(members) do
+    members
+    |> Enum.with_index
+    |> Enum.map(fn({member, index}) -> map_member_to_team(member, index) end)
+  end
+
+  defp map_member_to_team(member, index) do
+    %{ :member => member, :team => one_indexed(index) }
+  end
+
+  defp one_indexed(zero_index), do: zero_index + 1
+end

--- a/lib/team_builder.ex
+++ b/lib/team_builder.ex
@@ -1,9 +1,11 @@
 defmodule TeamBuilder do
   alias TeamBuilder.ConsoleWriter
   alias TeamBuilder.ConsoleReader
+  alias TeamBuilder.RandomTeamAllocator
+  alias TeamBuilder.RandomSelection
   alias TeamBuilder.TeamBuilderApp
 
   def main(_) do
-    TeamBuilderApp.start_application([], ConsoleReader, ConsoleWriter)
+    TeamBuilderApp.start_application([], ConsoleReader, ConsoleWriter, RandomTeamAllocator.team_allocator(RandomSelection))
   end
 end

--- a/lib/team_builder_app.ex
+++ b/lib/team_builder_app.ex
@@ -1,38 +1,38 @@
 defmodule TeamBuilder.TeamBuilderApp do
   alias TeamBuilder.Members
-  alias TeamBuilder.Team
+  alias TeamBuilder.Teams
   alias TeamBuilder.Commands
 
-  def start_application(members, display_reader, display_writer) do
-    display_reader.clear_screen()
+  def start_application(members, display_reader, display_writer, team_selector) do
+    display_writer.clear_screen()
     display_writer.welcome_message()
-    prompt_for_command(members, display_reader, display_writer)
+    prompt_for_command(members, display_reader, display_writer, team_selector)
   end
 
-  def prompt_for_command(members, display_reader, display_writer) do
+  def prompt_for_command(members, display_reader, display_writer, team_selector) do
     display_reader
     |> next_command
-    |> process_command(members, display_reader, display_writer)
+    |> process_command(members, display_reader, display_writer, team_selector)
   end
 
-  defp process_command(:quit, _, _, display_writer), do: display_writer.goodbye_message()
+  defp process_command(:quit, _, _, display_writer, _), do: display_writer.goodbye_message()
 
-  defp process_command(:build_teams, members, display_reader, display_writer) do
+  defp process_command(:build_teams, members, display_reader, display_writer, team_selector) do
     get_team_type()
-    |> build_teams(members, display_reader, display_writer)
-    prompt_for_command(members, display_reader, display_writer)
+    |> build_teams(members, display_reader, display_writer, team_selector)
+    prompt_for_command(members, display_reader, display_writer, team_selector)
   end
 
-  defp process_command({:add_member, new_member}, members, display_reader, display_writer) do
-    members
-    |> Members.add_to_members(new_member)
-    |> prompt_for_command(display_reader, display_writer)
+  defp process_command({:add_member, new_member}, members, display_reader, display_writer, team_selector) do
+    all_members = Members.add_to_members(members, new_member)
+    display_writer.display_members(all_members)
+    prompt_for_command(all_members, display_reader, display_writer, team_selector)
   end
 
-  defp build_teams(team_type, members, _, display_writer) do
+  defp build_teams(team_type, members, _, display_writer, team_selector) do
     display_writer.clear_screen()
     team_type
-    |> Team.allocate_members(members)
+    |> Teams.allocate_members(members, team_selector)
     |> display_writer.display_teams
   end
 

--- a/lib/teams.ex
+++ b/lib/teams.ex
@@ -1,43 +1,18 @@
-defmodule TeamBuilder.Team do
+defmodule TeamBuilder.Teams do
   def empty_teams(%{team_type: :fixed, options: fixed_count}) do
     Enum.map(1..fixed_count, fn(number) -> team_skeleton(number) end)
   end
 
-  def allocate_members(team_type, all_members) do
+  def allocate_members(team_type, all_members, team_allocator) do
     team_type
     |> empty_teams
-    |> _allocate_members(all_members)
+    |> _allocate_members(team_type, all_members, team_allocator)
   end
 
-  defp _allocate_members(teams, all_members) do
-    teams
-    |> assign_team_numbers(all_members)
+  defp _allocate_members(teams, team_type, all_members, team_allocator) do
+    all_members
+    |> team_allocator.(team_type)
     |> add_members(teams)
-  end
-
-  defp assign_team_numbers(teams, members) do
-    members
-    |> Enum.with_index
-    |> Enum.map(fn({member, index}) -> map_member_to_team(member, index, teams) end)
-  end
-
-  defp map_member_to_team(member, index, teams) do
-    %{:member => member, :team => get_team(index, teams)}
-  end
-
-  defp get_team(index, teams) do
-    teams
-    |> Enum.count
-    |> get_team_number(one_indexed(index))
-  end
-
-  defp get_team_number(max_team_number, member_number) when member_number <= max_team_number do
-    member_number
-  end
-
-  defp get_team_number(max_team_number, member_number) do
-    remainder = rem(member_number, max_team_number)
-    if remainder == 0, do: max_team_number, else: remainder
   end
 
   defp add_members([], teams), do: teams
@@ -62,6 +37,4 @@ defmodule TeamBuilder.Team do
   end
 
   defp team_skeleton(team_number), do: %{:team => team_number, :names => []}
-
-  defp one_indexed(zero_index), do: zero_index + 1
 end

--- a/lib/teams.ex
+++ b/lib/teams.ex
@@ -4,32 +4,31 @@ defmodule TeamBuilder.Teams do
   end
 
   def allocate_members(team_type, all_members, team_allocator) do
-    team_type
-    |> empty_teams
-    |> _allocate_members(team_type, all_members, team_allocator)
+    assign_team_numbers(all_members, team_type, team_allocator)
+    |> create_teams(team_type)
   end
 
-  defp _allocate_members(teams, team_type, all_members, team_allocator) do
+  defp assign_team_numbers(all_members, team_type, team_allocator) do
     all_members
     |> team_allocator.(team_type)
-    |> add_members(teams)
   end
 
-  defp add_members([], teams), do: teams
-
-  defp add_members([member | rest], teams) do
-    modified_teams = add_member(member, teams)
-    add_members(rest, modified_teams)
+  defp create_teams(members, team_type) do
+    team_type
+    |> empty_teams
+    |> add_team_members(members)
   end
 
-  defp add_member(member, teams) do
-    member_name = member[:member]
-    team_number = member[:team]
-    update_team(teams, team_number, member_name)
+  defp add_team_members(teams, []), do: teams
+
+  defp add_team_members(teams, [new_member | rest]) do
+    teams
+    |> update_team(new_member)
+    |> add_team_members(rest)
   end
 
-  defp update_team(teams, team_number, new_member) do
-    List.update_at(teams, team_number - 1, fn(team) -> update_member_list(team, new_member) end)
+  defp update_team(teams, %{member: new_member, team: team_number}) do
+    List.update_at(teams, zero_indexed(team_number), fn(team) -> update_member_list(team, new_member) end)
   end
 
   defp update_member_list(team, new_member) do
@@ -37,4 +36,6 @@ defmodule TeamBuilder.Teams do
   end
 
   defp team_skeleton(team_number), do: %{:team => team_number, :names => []}
+
+  defp zero_indexed(number), do: number - 1
 end

--- a/test/random_selection_test.exs
+++ b/test/random_selection_test.exs
@@ -1,0 +1,15 @@
+defmodule RandomSelectionTest do
+  use ExUnit.Case
+  doctest TeamBuilder
+  alias TeamBuilder.RandomSelection
+
+  test "any 4 elements selected from collection" do
+    team_count = 4
+    members = ["name1", "name2", "name3", "name4", "name5"]
+    assert contains_all?(members, RandomSelection.take_random(members, team_count))
+  end
+
+  def contains_all?(members, selection) do
+    Enum.all?(selection, fn(s) -> Enum.member?(members, s) end)
+  end
+end

--- a/test/random_team_allocator_test.exs
+++ b/test/random_team_allocator_test.exs
@@ -1,0 +1,29 @@
+defmodule RandomTeamAllocatorTest do
+  use ExUnit.Case
+  doctest TeamBuilder
+  alias TeamBuilder.RandomTeamAllocator
+
+  defmodule FakeRandomSelection do
+    def take_random(members, count), do: Enum.take(members, count)
+  end
+
+  test "assign 1 member to a team" do
+    members = ["Sarah"]
+    team_type = %{:team_type => :fixed, :options => 4 }
+    expected_result = [ %{ :member => "Sarah", :team => 1 } ]
+    assert RandomTeamAllocator.assign_teams(members, team_type, FakeRandomSelection) == expected_result
+  end
+
+  test "assign 5 members to 4 teams" do
+    members = ["name1", "name2", "name3", "name4", "name5"]
+    team_type = %{:team_type => :fixed, :options => 4 }
+    expected_result = [
+      %{ :member => "name1", :team => 1 },
+      %{ :member => "name2", :team => 2 },
+      %{ :member => "name3", :team => 3 },
+      %{ :member => "name4", :team => 4 },
+      %{ :member => "name5", :team => 1 }
+    ]
+    assert RandomTeamAllocator.assign_teams(members, team_type, FakeRandomSelection) == expected_result
+  end
+end

--- a/test/team_builder_app_test.exs
+++ b/test/team_builder_app_test.exs
@@ -6,6 +6,12 @@ defmodule TeamBuilderAppTest do
   alias TeamBuilder.TeamBuilderApp
   doctest TeamBuilder
 
+  defmodule FakeRandomSelection do
+    def take_random(members, count) do
+      Enum.take(members, count)
+    end
+  end
+
   @team_type %{:team_type => :fixed, :options => 4}
 
   defmodule FakeReader do
@@ -25,24 +31,27 @@ defmodule TeamBuilderAppTest do
   end
 
   test "typing q, closes the application" do
-    assert TeamBuilderApp.prompt_for_command([], FakeReader, FakeWriter) == "GoodBye"
+    team_allocator = TeamBuilder.RandomTeamAllocator.team_allocator(FakeRandomSelection)
+    assert TeamBuilderApp.prompt_for_command([], FakeReader, FakeWriter, team_allocator) == "GoodBye"
   end
 
   test "typing b, builds the 4 empty teams" do
     input = "b\nq\n"
+    team_allocator = TeamBuilder.RandomTeamAllocator.team_allocator(FakeRandomSelection)
     expected_result = "[ Team 1 ]\n\n" <>
                       "[ Team 2 ]\n\n" <>
                       "[ Team 3 ]\n\n" <>
                       "[ Team 4 ]\n\n" <>
                       "Thank you for using TeamBuilder.\n"
     result = capture_io([input: input, capture_prompt: false], fn() ->
-      IO.write TeamBuilderApp.prompt_for_command([], ConsoleReader, ConsoleWriter)
+      IO.write TeamBuilderApp.prompt_for_command([], ConsoleReader, ConsoleWriter, team_allocator)
     end)
     assert String.contains?(result, expected_result)
   end
 
   test "consecutive new members redistributed across teams" do
     input = "Sarah\nJames\nb\nq\n"
+    team_allocator = TeamBuilder.RandomTeamAllocator.team_allocator(FakeRandomSelection)
     expected_result = "[ Team 1 ]\n" <>
                        "[1] Sarah\n\n" <>
                        "[ Team 2 ]\n" <>
@@ -51,7 +60,7 @@ defmodule TeamBuilderAppTest do
                        "[ Team 4 ]\n\n" <>
                        "Thank you for using TeamBuilder.\n"
     result = capture_io([input: input, capture_prompt: false], fn() ->
-      IO.write TeamBuilderApp.prompt_for_command([], ConsoleReader, ConsoleWriter)
+      IO.write TeamBuilderApp.prompt_for_command([], ConsoleReader, ConsoleWriter, team_allocator)
     end)
     assert String.contains?(result, expected_result)
   end

--- a/test/teams_test.exs
+++ b/test/teams_test.exs
@@ -1,37 +1,45 @@
 defmodule TeamTest do
   use ExUnit.Case
   doctest TeamBuilder
-  alias TeamBuilder.Team
+  alias TeamBuilder.Teams
+
+  defmodule FakeRandomSelection do
+    def take_random(members, count) do
+      Enum.take(members, count)
+    end
+  end
 
   @team_type %{:team_type => :fixed, :options => 4}
 
   test "fixed number of teams created" do
     fixed_number_of_teams = 4
     expected_result = get_teams(fixed_number_of_teams)
-    assert Team.empty_teams(@team_type) == expected_result
+    assert Teams.empty_teams(@team_type) == expected_result
   end
 
   test "two members generates two Teams" do
     [a1, a2] = generate_members(2)
+    team_allocator = TeamBuilder.RandomTeamAllocator.team_allocator(FakeRandomSelection)
     expected_result = [
               %{:team => 1, :names => [a1]},
               %{:team => 2, :names => [a2]},
               %{:team => 3, :names => []},
               %{:team => 4, :names => []}
             ]
-    assert Team.allocate_members(@team_type, [a1, a2]) == expected_result
+    assert Teams.allocate_members(@team_type, [a1, a2], team_allocator) == expected_result
   end
 
   test "eight members generates 4 Teams with 2 members each" do
-    [a1, a2, a3, a4, a5, a6, a7, a8] = generate_members(8)
-    all_members = [a1, a2, a3, a4, a5, a6, a7, a8]
+    all_members = generate_members(8)
+    [a1, a2, a3, a4, a5, a6, a7, a8] = all_members
+    team_allocator = TeamBuilder.RandomTeamAllocator.team_allocator(FakeRandomSelection)
     expected_result = [
               %{:team => 1, :names => [a1, a5] },
               %{:team => 2, :names => [a2, a6] },
               %{:team => 3, :names => [a3, a7] },
               %{:team => 4, :names => [a4, a8] }
             ]
-    assert Team.allocate_members(@team_type, all_members) == expected_result
+    assert Teams.allocate_members(@team_type, all_members, team_allocator) == expected_result
   end
 
   def generate_members(number) do


### PR DESCRIPTION
Impure functions due to impure random selection: Enum.take_random.
A solution will be to use a 'seed' value.  The seed value will be truly random and generated at the 'application level'.  Based on what the seed is, the order of of the random selection will be the same and therefore the function itself will be pure.  eg given a seed value 'X' the random selection by Enum.take_random will always be made in the same order.
example:
iex> :rand.seed({:exsplus, [244613228392096739 | 259777416340182517]})
iex > Enum.take_random([1,2,3,4,5], 3)
iex > [3, 1,5]
iex > [2, 3, 1]
iex> :rand.seed({:exsplus, [244613228392096739 | 259777416340182517]})
iex > Enum.take_random([1,2,3,4,5], 3)
iex > [3, 1,5]
iex > [2, 3, 1]

Trade off: 
I've created 'command' atom's for :quit, :build_teams or :add_member and how they are handled is managed by TeamBuilderApp.  However, I could have instead created modules like Quit, BuildTeams, and AddMember and let them handle the 'event'.  I chose the former because the processing involved for each command isn't extensive, however I'm not 100% sure.
@maikon
@jsuchy
@felipesere
