### PR TITLE
Correct TeamAllocator::remaining_members to fix duplicate name bug.

### DIFF
--- a/lib/team_allocator.ex
+++ b/lib/team_allocator.ex
@@ -28,8 +28,7 @@ defmodule TeamBuilder.TeamAllocator do
   end
 
   defp remaining_members(selected_members, all_members) do
-    {_, remaining} = Enum.partition(all_members, fn(x) -> Enum.any?(selected_members, fn(s) -> s == x end) end)
-    remaining
+    all_members -- selected_members
   end
 
   defp one_indexed(zero_index), do: zero_index + 1

--- a/test/team_allocator_test.exs
+++ b/test/team_allocator_test.exs
@@ -12,6 +12,15 @@ defmodule TeamAllocatorTest do
     assert TeamAllocator.members_selection(members, number_of_members, seed_state) == expected
   end
 
+  test "select 4 members with the same name" do
+    number_of_members = 4
+    members = ["Sarah", "Sarah", "Sarah", "Sarah"]
+    seed_state = :rand.export_seed_s(:rand.seed(:exsplus))
+    selected = Enum.take_random(members, number_of_members)
+    expected = {selected, TestHelper.remaining_members(selected, members), :rand.export_seed()}
+    assert TeamAllocator.members_selection(members, number_of_members, seed_state) == expected
+  end
+
   test "map a member to a team" do
     member = "Sarah"
     team = 1

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,4 +8,19 @@ defmodule TestHelper do
   def remaining_members(selected_members, all_members) do
     all_members -- selected_members
   end
+
+  def get_teams(0) do
+    [
+      %{:team => 1, :names => []},
+    ]
+  end
+
+  def get_teams(4) do
+    [
+      %{:team => 1, :names => []},
+      %{:team => 2, :names => []},
+      %{:team => 3, :names => []},
+      %{:team => 4, :names => []},
+    ]
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,23 +5,7 @@ defmodule TestHelper do
     Enum.map(1..number, fn(num) -> "name#{num}" end)
   end
 
-  def get_teams(0) do
-    [
-      %{:team => 1, :names => []},
-    ]
-  end
-
-  def get_teams(4) do
-    [
-      %{:team => 1, :names => []},
-      %{:team => 2, :names => []},
-      %{:team => 3, :names => []},
-      %{:team => 4, :names => []},
-    ]
-  end
-
   def remaining_members(selected_members, all_members) do
-    {_, remaining} = Enum.partition(all_members, fn(x) -> Enum.any?(selected_members, fn(s) -> s == x end) end)
-    remaining
+    all_members -- selected_members
   end
 end


### PR DESCRIPTION
I noticed that when there were duplicate names in the members list, they weren't all
showing up in the final team allocations.
I discovered there really is a simple way for diffing two Lists! It's called subtraction
with a double '--'.
@maikon
@jsuchy
